### PR TITLE
Fix minor typos on home page

### DIFF
--- a/views/home.jade
+++ b/views/home.jade
@@ -73,12 +73,12 @@ block content
                   | with your friends.
                   br
                   br
-                  | This is a Beta version of the project, anybody is welcomed
+                  | This is a Beta version of the project, anybody is welcome
                   | to contribute, comment, or test the game and the website.
             .col-lg-4
                p
                   | The whole project is open-source and is availble on Github. SmallWorld was
-                  | built using Nodejs, Createljs, & the websocket library Socket.io. If you share
+                  | built using Node.js, CreateJS, & the websocket library Socket.io. If you share
                   | an intrest in the game or you have any comments,
                   | please let me know. Thank you!
             .col-lg-8.col-lg-offset-2.text-center


### PR DESCRIPTION
Noticed that CreateJS was mistyped as CreatelJS. Went ahead and cased
other names in a common fashion also.